### PR TITLE
Specific Routes

### DIFF
--- a/keep-circulating-supply/main.py
+++ b/keep-circulating-supply/main.py
@@ -18,7 +18,4 @@ def main(request):
     keep_token_grant = keep_token_contract.functions.balanceOf('0x175989c71Fd023D580C65F5dC214002687ff88B7').call()
     magic_subtractor = 59053770 * (10 ** 18)
     keep_circulating_supply = keep_total_supply - keep_token_grant - magic_subtractor
-    supply_in_tokens = keep_circulating_supply / (10 ** 18)
-    ret = {}
-    ret['est_circulating_supply'] = supply_in_tokens
-    return json.dumps(ret)
+    return str(keep_circulating_supply / (10 ** 18))

--- a/keep-circulating-supply/main.py
+++ b/keep-circulating-supply/main.py
@@ -18,4 +18,16 @@ def main(request):
     keep_token_grant = keep_token_contract.functions.balanceOf('0x175989c71Fd023D580C65F5dC214002687ff88B7').call()
     magic_subtractor = 59053770 * (10 ** 18)
     keep_circulating_supply = keep_total_supply - keep_token_grant - magic_subtractor
-    return str(keep_circulating_supply / (10 ** 18))
+    est_circulating_supply = keep_circulating_supply / (10 ** 18)
+    results = {
+        'total_supply': keep_total_supply / (10 ** 18),
+        'est_circulating_supply': est_circulating_supply
+    }
+    if request.path == '/total':
+        return str(results['total_supply'])
+    elif request.path == '/circulating':
+        return str(est_circulating_supply)
+    elif request.path == '/':
+        return json.dumps(results)
+    else:
+        return f'unknown route {request.path}'

--- a/t-circulating-supply/main.py
+++ b/t-circulating-supply/main.py
@@ -64,5 +64,7 @@ def main(request):
 
                 if request.path == "/circulating":
                     return str(circulating_t_tokens)
-                else:
+                elif request.path == '/':
                     return json.dumps(results)
+                else:
+                    return f'unknown route {request.path}'

--- a/t-circulating-supply/main.py
+++ b/t-circulating-supply/main.py
@@ -12,7 +12,6 @@ def main(request):
         `make_response <http://flask.pocoo.org/docs/1.0/api/#flask.Flask.make_response>`.
     """
 
-
     address = '0xCdF7028ceAB81fA0C6971208e83fa7872994beE5'
     with open('t-contract.abi') as t_contract_file:
         abi = t_contract_file.read()
@@ -28,7 +27,14 @@ def main(request):
                 nu_token_contract = w3.eth.contract(address=address, abi=abi)
 
                 t_total_supply = t_token_contract.functions.totalSupply().call()
+
+                if request.path == "/total":
+                    return str(t_total_supply / (10 ** 18))
+
                 t_treasury_supply = t_token_contract.functions.balanceOf('0x9F6e831c8F8939DC0C830C6e492e7cEf4f9C2F5f').call()
+                if request.path == "/treasury":
+                    return str(t_treasury_supply / (10 ** 18))
+
                 nu_vending_machine = t_token_contract.functions.balanceOf('0x1CCA7E410eE41739792eA0A24e00349Dd247680e').call()
 
                 nu_token_factor = 3.25924249316
@@ -55,4 +61,8 @@ def main(request):
                         'dao_treasury_supply': t_treasury_supply / (10 ** 18),
                         'est_circulating_supply': circulating_t_tokens
                 }
-                return json.dumps(results)
+
+                if request.path == "/circulating":
+                    return str(circulating_t_tokens)
+                else:
+                    return json.dumps(results)


### PR DESCRIPTION
This PR changes the t-circulating-supply function to add the following routes:

+ `/total` returns just the total supply
+ `/treasury` returns the treasury supply
+ `/circulating` return the circulating supply

We also go ahead and drop the json output from keep-circulating-supply in favor of just returning a number, so that places like coinmarketcap have to do as little work as possible

Tagging @pdyraga for review