### PR TITLE
Hardcode NU's Circulating Supply

### DIFF
--- a/t-circulating-supply/main.py
+++ b/t-circulating-supply/main.py
@@ -20,8 +20,6 @@ MAGIC_KEEP_SUPPLY_SUBTRACTOR = 59053770 * WEI_FACTOR
 INITIAL_T_SUPPLY = 10_000_000_000 * WEI_FACTOR  # 10B T
 INITIAL_TREASURY_SUPPLY = 1_000_000_000 * WEI_FACTOR  # 1B T
 
-NU_CIRCULATING_SUPPLY_ENDPOINT = "https://status.nucypher.network/supply_information?q=est_circulating_supply"
-
 # Merkle Distribution
 MERKLE_DISTRIBUTION_SUMMARY_ENDPOINT = f"https://raw.githubusercontent.com/threshold-network/merkle-distribution/main/distributions/distributions.json"
 

--- a/t-circulating-supply/main.py
+++ b/t-circulating-supply/main.py
@@ -84,8 +84,7 @@ def main(request):
     #
 
     # NU Tokens Calc
-    nu_circulating_supply = make_request(NU_CIRCULATING_SUPPLY_ENDPOINT, verify=False)
-    circulating_t_from_nu = nu_circulating_supply * NU_TOKEN_FACTOR * WEI_FACTOR
+    circulating_t_from_nu = 1380688920 * NU_TOKEN_FACTOR * WEI_FACTOR # Nu is fully circulating at 1.38B
 
     # KEEP Tokens Calc
     keep_token_contract = w3.eth.contract(address=KEEP_TOKEN_ADDRESS, abi=abi)


### PR DESCRIPTION
The t-circulating-supply endpoint is currently breaking because it cannot make calls to https://status.nucypher.network/supply_information?q=est_circulating_supply

Rather than try to bring that endpoint back online, we can hardcode nu's circulating supply since it won't be changing.

Tagging @derekpierre for review